### PR TITLE
geografische Stichworte hinzugefügt

### DIFF
--- a/SaraceniMaximalschema.xml
+++ b/SaraceniMaximalschema.xml
@@ -268,6 +268,14 @@
             <creation>
                Anmerkungen aus der Edition
             </creation>
+            <!-- hier die geografischen Stichworte: -->
+            <settingDesc>
+               <listPlace>
+                  <place>
+                     <placeName>Ortsname</placeName>
+                  </place>
+               </listPlace>
+            </settingDesc>
             <!-- hier die Berichte: ein <person> für jedes Individuum und eine <personGrp> für jedes Kollektivum. -->
             <particDesc>
                <listPerson>


### PR DESCRIPTION
habe ich im Maximalschema vergessen, die Auszeichnung der geografischen Stichworte im <settingDesc>. Leider akzeptiert TEI nur diese verschachtelte Struktur ...